### PR TITLE
Enable constructorBytecode argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Required options:
   --artifactFile <BUILD_INFO_FILE_PATH>  Path to the build info file containing Solidity compiler input and output for the contract.
 
 Additional options:
-  --constructorBytecode <CONSTRUCTOR_BYTECODE>  ABI encoded byte string representing the constructor arguments. Required if the constructor has arguments.
+  --constructorBytecode <CONSTRUCTOR_BYTECODE>  0x-prefixed ABI encoded byte string representing the constructor arguments. Required if the constructor has arguments.
   --licenseType <LICENSE>         License type for the contract. Recommended if verifying source code. Defaults to "None".
   --verifySourceCode <true|false>  Whether to verify source code on block explorers. Defaults to true.
   --relayerId <RELAYER_ID>        Relayer ID to use for deployment. Defaults to the relayer configured for your deployment environment on Defender.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ DEFENDER_SECRET<Your API secret>
 ## Usage
 
 ```
-npx @openzeppelin/defender-deploy-client-cli deploy --contractName <CONTRACT_NAME> --contractPath <CONTRACT_PATH> --chainId <CHAIN_ID> --artifactFile <BUILD_INFO_FILE_PATH> [--constructorBytecode <CONSTRUCTOR_ARGS>] [--licenseType <LICENSE>] [--verifySourceCode <true|false>] [--relayerId <RELAYER_ID>] [--salt <SALT>] [--createFactoryAddress <CREATE_FACTORY_ADDRESS>]
+npx @openzeppelin/defender-deploy-client-cli deploy --contractName <CONTRACT_NAME> --contractPath <CONTRACT_PATH> --chainId <CHAIN_ID> --artifactFile <BUILD_INFO_FILE_PATH> [--constructorBytecode <CONSTRUCTOR_BYTECODE>] [--licenseType <LICENSE>] [--verifySourceCode <true|false>] [--relayerId <RELAYER_ID>] [--salt <SALT>] [--createFactoryAddress <CREATE_FACTORY_ADDRESS>]
 
 Deploys a contract using OpenZeppelin Defender.
 
@@ -30,7 +30,7 @@ Required options:
   --artifactFile <BUILD_INFO_FILE_PATH>  Path to the build info file containing Solidity compiler input and output for the contract.
 
 Additional options:
-  --constructorBytecode <CONSTRUCTOR_BYTECODE>  COMING SOON, NOT CURRENTLY USED. This will be an ABI encoded byte string representing the constructor arguments. Required if the constructor has arguments.
+  --constructorBytecode <CONSTRUCTOR_BYTECODE>  ABI encoded byte string representing the constructor arguments. Required if the constructor has arguments.
   --licenseType <LICENSE>         License type for the contract. Recommended if verifying source code. Defaults to "None".
   --verifySourceCode <true|false>  Whether to verify source code on block explorers. Defaults to true.
   --relayerId <RELAYER_ID>        Relayer ID to use for deployment. Defaults to the relayer configured for your deployment environment on Defender.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openzeppelin/defender-deploy-client-cli",
-  "version": "0.0.1-alpha.1",
+  "version": "0.0.1-alpha.2",
   "description": "CLI for deployments using OpenZeppelin Defender SDK",
   "repository": "https://github.com/OpenZeppelin/defender-deploy-client-cli",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
   },
   "dependencies": {
     "minimist": "^1.2.8",
-    "@openzeppelin/defender-sdk-deploy-client": "^1.8.0",
-    "@openzeppelin/defender-sdk-base-client": "^1.8.0",
+    "@openzeppelin/defender-sdk-deploy-client": "^1.9.0",
+    "@openzeppelin/defender-sdk-base-client": "^1.9.0",
     "dotenv": "^16.3.1"
   }
 }

--- a/src/defender.ts
+++ b/src/defender.ts
@@ -13,7 +13,7 @@ Required options:
   --artifactFile <BUILD_INFO_FILE_PATH>  Path to the build info file containing Solidity compiler input and output for the contract.
 
 Additional options:
-  --constructorBytecode <CONSTRUCTOR_BYTECODE>  ABI encoded byte string representing the constructor arguments. Required if the constructor has arguments.
+  --constructorBytecode <CONSTRUCTOR_BYTECODE>  0x-prefixed ABI encoded byte string representing the constructor arguments. Required if the constructor has arguments.
   --licenseType <LICENSE>         License type for the contract. Recommended if verifying source code. Defaults to "None".
   --verifySourceCode <true|false>  Whether to verify source code on block explorers. Defaults to true.
   --relayerId <RELAYER_ID>        Relayer ID to use for deployment. Defaults to the relayer configured for your deployment environment on Defender.

--- a/src/defender.ts
+++ b/src/defender.ts
@@ -13,7 +13,7 @@ Required options:
   --artifactFile <BUILD_INFO_FILE_PATH>  Path to the build info file containing Solidity compiler input and output for the contract.
 
 Additional options:
-  --constructorBytecode <CONSTRUCTOR_BYTECODE>  COMING SOON, NOT CURRENTLY USED. This will be an ABI encoded byte string representing the constructor arguments. Required if the constructor has arguments.
+  --constructorBytecode <CONSTRUCTOR_BYTECODE>  ABI encoded byte string representing the constructor arguments. Required if the constructor has arguments.
   --licenseType <LICENSE>         License type for the contract. Recommended if verifying source code. Defaults to "None".
   --verifySourceCode <true|false>  Whether to verify source code on block explorers. Defaults to true.
   --relayerId <RELAYER_ID>        Relayer ID to use for deployment. Defaults to the relayer configured for your deployment environment on Defender.

--- a/src/deployContract.ts
+++ b/src/deployContract.ts
@@ -35,7 +35,7 @@ export async function deployContract(args: FunctionArgs) {
     network: args.network,
     artifactPayload: buildInfoFileContents,
     licenseType: args.licenseType as SourceCodeLicense | undefined, // cast without validation but catch error from API below
-    // constructorBytecode: args.constructorBytecode, // TODO enable this when Defender SDK supports it
+    constructorBytecode: args.constructorBytecode,
     verifySourceCode: args.verifySourceCode,
     relayerId: args.relayerId,
     salt: args.salt,

--- a/yarn.lock
+++ b/yarn.lock
@@ -260,21 +260,21 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@openzeppelin/defender-sdk-base-client@^1.8.0":
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/defender-sdk-base-client/-/defender-sdk-base-client-1.8.0.tgz#2209a060ce61b4dfc44c7ac0c2b1d86e18b69f7d"
-  integrity sha512-XIJat6BW2CTM74AwG5IL0Q/aE6RXj8x7smnVKmBql4wMvmirVW+njfwzZCLhUTiBXg9AlHxIInEF14SabfIisg==
+"@openzeppelin/defender-sdk-base-client@^1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/defender-sdk-base-client/-/defender-sdk-base-client-1.9.0.tgz#2596ab12edc44236290720cd4a89cedbc480b3c0"
+  integrity sha512-ywxZslKaY7Z5z9APpBunIDp4nXkGnYZAStaIhzzh8vbbzu7lxiZO98tsX3B9vCefqWC4oyX0mm78CdyYUgW5KQ==
   dependencies:
     amazon-cognito-identity-js "^6.3.6"
     async-retry "^1.3.3"
 
-"@openzeppelin/defender-sdk-deploy-client@^1.8.0":
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/defender-sdk-deploy-client/-/defender-sdk-deploy-client-1.8.0.tgz#1e186d2b3ff176c6a4c03e8207bad8022528975f"
-  integrity sha512-/tNS2EnHuA5l095wzMbIkGMDNHZLcZQ2eLUP8z+AeKaAUeR2z4qzZ1ul21kR3EJURAyoy8aULFZanLggoBWHrA==
+"@openzeppelin/defender-sdk-deploy-client@^1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/defender-sdk-deploy-client/-/defender-sdk-deploy-client-1.9.0.tgz#ad2f61912f066386a22221bdcbd73d52b91e4c74"
+  integrity sha512-xw3qRJzE3XQRBoBBqOC7VOEtaVnzeN9EgsBZSjWlDUcmfJ6jdUuUsoqEkwYBZVEi+Dr3ujURY2DsmEvs0gFoNw==
   dependencies:
     "@ethersproject/abi" "^5.7.0"
-    "@openzeppelin/defender-sdk-base-client" "^1.8.0"
+    "@openzeppelin/defender-sdk-base-client" "^1.9.0"
     axios "^1.4.0"
     lodash "^4.17.21"
 


### PR DESCRIPTION
Enables `constructorBytecode` argument. Requires updated version of `@openzeppelin/defender-sdk-deploy-client`.